### PR TITLE
Trick: make "OpenDVC_model" visible to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Email: ren.yang@vision.ee.ethz.ch
 
 - Pre-trained models ([Download link](https://drive.google.com/drive/folders/1gUkf9FNjiZw6Pcr5U_bl3jgbM1_ZpB2K?usp=sharing))
 
-  (*Download the folder "OpenDVC_model" to the same directory as the codes.*)
+  (*Download model to "OpenDEV_model" directory  as the codes describe.*)
 
 - BPG ([Download link](https://bellard.org/bpg/))  -- needed only for the PSNR models
 


### PR DESCRIPTION
hi @RenYang-home 

i create a blank file `.gitkeep` as a placeholder to make `OpenDVC_model` directory visible to github

Maybe this will make it easier for people to understand how to deploy OpenDVC

have a nice day